### PR TITLE
1) Version bump chain and runtime to 0.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katal-chain"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Trinkler Software <company@trinkler.software>"]
 build = "node/build.rs"
 edition = "2018"

--- a/modules/actus/Cargo.toml
+++ b/modules/actus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modules-actus"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Trinkler Software <company@trinkler.software>"]
 edition = "2018"
 

--- a/modules/oracle/Cargo.toml
+++ b/modules/oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modules-oracle"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Trinkler Software <company@trinkler.software>"]
 edition = "2018"
 

--- a/modules/ownership/Cargo.toml
+++ b/modules/ownership/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modules-ownership"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Trinkler Software <company@trinkler.software>"]
 edition = "2018"
 

--- a/modules/reals/Cargo.toml
+++ b/modules/reals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modules-reals"
-version = "1.0.0"
+version = "0.0.2"
 authors = ["Trinkler Software <company@trinkler.software>"]
 edition = "2018"
 

--- a/modules/time/Cargo.toml
+++ b/modules/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modules-time"
-version = "1.0.0"
+version = "0.0.2"
 authors = ["Trinkler Software <company@trinkler.software>"]
 edition = "2018"
 

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katal-runtime"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Trinkler Software <company@trinkler.software>"]
 edition = "2018"
 


### PR DESCRIPTION
2) Version bump all modules to 0.0.2

Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

- Version bump of chain, runtime and modules to 0.0.2

### Deprecated

### Removed

### Fixed

### Security
